### PR TITLE
Fix duplicate declaration of Quote::customer

### DIFF
--- a/laravel/app/Models/Quote.php
+++ b/laravel/app/Models/Quote.php
@@ -30,14 +30,6 @@ class Quote extends Model
     }
 
     /**
-     * Get the associate that owns the quote.
-     */
-    public function customer()
-    {
-        return $this->belongsTo(Customer::class);
-    }
-
-    /**
      * Get the line items for the quote.
      */
     public function line_items()


### PR DESCRIPTION
We had two copies of the customer function that were created because of the last merge commit, which caused a fatal error. I removed one of them and it resolved the issue.