### PR TITLE
Test

### DIFF
--- a/laravel/app/Http/Controllers/LineItemController.php
+++ b/laravel/app/Http/Controllers/LineItemController.php
@@ -3,8 +3,46 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\LineItem;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Response;
 
 class LineItemController extends Controller
 {
-    //
+    /**
+     * Get a validator for an incoming newquote request.
+     *
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    protected function validator(array $data)
+    {
+        return Validator::make($data, [
+            'id' => ['required','int'],
+            'description' => ['required','string'],
+            'price' => ['required','numeric'],
+            'quantity' => ['required','int']
+        ]);
+    }
+
+    public function update(Request $request){
+        $validator = $this->validator($request->all());
+        if ($validator->fails ())
+            return Response::json ( array (             
+                    'errors' => $validator->getMessageBag ()->toArray () 
+            ) );
+        else {
+            $line_item = LineItem::find ( $request->id );
+            $line_item->description = ($request->description);
+            $line_item->price = ($request->price);
+            $line_item->quantity = ($request->quantity);
+            $line_item->save ();
+            return response ()->json ( $line_item );
+        }
+    }
+
+    public function destroy(Request $request){
+        LineItem::find ( $request->id )->delete ();
+        return response ()->json ();
+    }
 }

--- a/laravel/app/Http/Controllers/LineItemController.php
+++ b/laravel/app/Http/Controllers/LineItemController.php
@@ -45,4 +45,21 @@ class LineItemController extends Controller
         LineItem::find ( $request->id )->delete ();
         return response ()->json ();
     }
+
+    public function create(Request $request) {
+        $validator = $this->validator($request->all());
+        if ($validator->fails ())
+            return Response::json ( array (
+                    'errors' => $validator->getMessageBag ()->toArray ()
+            ) );
+            else {
+                $line_item = new LineItem();
+                $line_item->quote_id = ($request->quote_id);
+                $line_item->description = ($request->description);
+                $line_item->price = ($request->price);
+                $line_item->quantity = ($request->quantity);
+                $line_item->save ();
+                return response ()->json ( $line_item );
+            }
+    }
 }

--- a/laravel/app/Models/Data.php
+++ b/laravel/app/Models/Data.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Data extends Model
+{
+    use HasFactory;
+    protected $itemsTable="datatables_data";
+
+}

--- a/laravel/resources/views/layouts/app.blade.php
+++ b/laravel/resources/views/layouts/app.blade.php
@@ -11,13 +11,15 @@
 
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
-
+    @stack('script')
+    
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
 
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+
 </head>
 <body>
     <div id="app">

--- a/laravel/resources/views/quote.blade.php
+++ b/laravel/resources/views/quote.blade.php
@@ -131,7 +131,7 @@
 </div>
 @endsection
 
-            <div id="myModal" class="modal" role="dialog">
+            <div id="myModal" class="modal hide fade" role="dialog" style="display:none;">
                 <div class="modal-dialog">
                     <!-- Modal content-->
                     <div class="modal-content">
@@ -321,7 +321,7 @@
                 'id': $('.did').text()
             },
             success: function(data) {
-                $('.item' + $('.did').text()).remove();
+                $('#item' + $('.did').text()).remove();
             }
         });
     });

--- a/laravel/resources/views/quote.blade.php
+++ b/laravel/resources/views/quote.blade.php
@@ -93,12 +93,15 @@
                                 </td>
                             </tr>
                         @endforeach
-                            <tr>
+                            <tr><<form class="form-horizontal" role="form">>
                                 <td><input class="form-control" type="text" name="description" placeholder="Description"></td>
                                 <td><input class="form-control" type="number" name="price" placeholder="Price"></td>
                                 <td><input class="form-control" type="number" name="quantity" placeholder="Quantity"></td>
-                                <td><input class="form-control" type="number" name="test" placeholder="test"></td>
-                            </tr>
+                                <!--td><input class="form-control" type="number" name="test" placeholder="test"></td-->
+                                <td><button class="btn btn-primary" type="submit" id="create">
+                                         <span class="glyphicon glyphicon-plus">ADD</span>
+                                    </button></td>
+                            </form></tr>
                         </tbody>
                     </table>
                 </div>
@@ -201,7 +204,7 @@
                 $('.actionBtn').removeClass('delete');
                 $('.actionBtn').addClass('edit');
                 $('.modal-title').text('Edit');
-                //$('.deleteContent').hide();
+                $('.deleteContent').hide();
                 $('.form-horizontal').show();
                 var stuff = $(this).data('info').split(',');
                 fillmodalData(stuff)
@@ -210,7 +213,7 @@
 
     function fillmodalData(details){
         var path = window.location.pathname.split('/');
-        //$('#id').val(path[2]);
+        //$('#qid').val(path[2]);
         $('#id').val(details[0]);
         $('#description').val(details[1]);
         $('#price').val(details[2]);
@@ -256,45 +259,42 @@
                              + data.id+","+data.description+","+data.price+","+data.quantity+
                              "' ><span class='glyphicon glyphicon-trash'></span> Delete</button></td></tr>"
                             );
-                        //$('#itemsTable').DataTable().clear();
-                        //$('#itemsTable').DataTable().ajax.url(window.location.pathname).load();
                     }
                 }
             });
     });
 
-    /*$("#add").click(function() {
+    $("#create").click(function() {
+        var path = window.location.pathname.split('/');
         $.ajax({
             type: 'post',
-            url: '/addItem',
+            url: '/api/lineitems/create',
             data: {
                 '_token': $('input[name=_token]').val(),
-                'name': $('input[name=name]').val()
+                'quote_id':$('#quote_id').val(path[2]),
+                'description': $('input[name=description]').val(),
+                'price': $('input[name=price]').val(),
+                'quantity': $('input[name=quantity]').val(),
             },
-            success: function(data) {
-                if ((data.errors)){
-                $('.error').removeClass('hidden');
-                    $('.error').text(data.errors.name);
-                }
-                else {
-                    $('.error').addClass('hidden');
-                    $('#itemsTable').append("<tr class='item" + line_items.id + "'><td>" + line_items.id + 
-                    "</td><td>" + line_items.desc + "</td><td>" + line_items.price + "</td><td>" + 
-                    line_items.quant + "</td><td><button class='edit-modal btn btn-info' data-id='" + 
-                    line_items.id + "' data-desc='" + line_items.desc + "' data-price='" + line_items.price 
-                    + "' data-quant='" + line_items.quant + 
-                    "'><span class='glyphicon glyphicon-edit'></span> Edit</button> <button class='delete-modal btn btn-danger' data-id='" 
-                    + line_items.id + "' data-desc='" + line_items.desc + "'' data-price='" + line_items.price 
-                    + "'' data-quant='" + line_items.quant + "'><span class='glyphicon glyphicon-trash'></span> Delete</button></td></tr>"
-                    );
-                }
+            success: function(data) 
+            {
+                $('.error').addClass('hidden');
+                $('#itemsTable').append("<tr id='item" + data.id + "'><td>" + data.description +
+                "</td><td class='text-right'>" + data.price + "</td><td class='text-right'>" + data.quantity +
+                "</td><td><button class='edit-modal btn btn-info' data-info='" + 
+                data.id+","+data.description+","+data.price+","+data.quantity+
+                "'><span class='glyphicon glyphicon-edit'></span> Edit</button> <button class='delete-modal btn btn-danger' data-info='"
+                + data.id+","+data.description+","+data.price+","+data.quantity+
+                "' ><span class='glyphicon glyphicon-trash'></span> Delete</button></td></tr>"
+                );
             },
-
         });
-        $('#desc').val('');
+        $('#quote_id').val('');
+        $('#description').val('');
         $('#price').val('');
-        $('#quant').val('');
-    });*/
+        $('#quantity').val('');
+    });
+
     $(document).on('click', '.delete-modal', function() {
         $('#footer_action_button').text(" Delete");
         $('#footer_action_button').removeClass('glyphicon-check');

--- a/laravel/resources/views/quote.blade.php
+++ b/laravel/resources/views/quote.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-8">
+        <div class="col-md-10">
             <div class="card">
                 <div class="card-header">
                 @canany(['edit own quote', 'edit finalized quote'])
@@ -22,7 +22,7 @@
                         <div class="form-group row">
                             <label for="customer_id" class="col-md-4 col-form-label text-md-right">{{ __('Customer') }}</label>
 
-                            <div class="col-md-6">
+                            <div class="col-md-8">
                                 <select disabled id="customer_id" class="form-control @error('customer_id') is-invalid @enderror" name="customer_id" required autofocus>
                                 @foreach($customers as $customer)
                                     <option @if($quote->customer_id == $customer->id) selected @endif value="{{$customer->id}}">{{$customer->name}}</option>
@@ -39,7 +39,7 @@
                         <div class="form-group row">
                             <label for="customer_email" class="col-md-4 col-form-label text-md-right">{{ __('Contact Email') }}</label>
 
-                            <div class="col-md-6">
+                            <div class="col-md-8">
                                 <input id="customer_email" type="text" class="form-control @error('customer_email') is-invalid @enderror" name="customer_email" value="{{ $quote->customer_email }}" required>
 
                                 @error('customer_email')
@@ -51,7 +51,7 @@
                         </div>
 
                         <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
+                            <div class="col-md-8 offset-md-4">
                                 <button type="submit" class="btn btn-primary">
                                     {{ __('Update quote') }}
                                 </button>
@@ -64,26 +64,40 @@
             <div class="card">
                 <div class="card-header">Line items</div>
                 <div class="card-body">
-                    <table class="table table-striped table-hover table-condensed">
+                    <table class="table table-striped table-hover table-condensed" id="itemsTable">
                         <thead>
                         <tr>
                             <th>Description</th>
                             <th class="text-right">Price</th>
                             <th class="text-right">Quantity</th>
+                            <th class="text-right">Action</th>
                         </tr>
                         </thead>
                         <tbody>
                         @foreach($line_items as $line_item)
-                            <tr>
+                            <tr id='item{{$line_item->id}}'>
                                 <td>{{$line_item->description}}</td>
                                 <td class="text-right">{{$line_item->price}}</td>
                                 <td class="text-right">{{$line_item->quantity}}</td>
+                                <td>
+                                    <button class="edit-modal btn btn-info"
+                                    data-info="{{$line_item->id}},{{$line_item->description}},{{$line_item->price}},
+                                    {{$line_item->quantity}}">
+                                        <span class="glyphicon glyphicon-edit"></span> Edit
+                                    </button>
+                                    <button class="delete-modal btn btn-danger"
+                                    data-info="{{$line_item->id}},{{$line_item->description}},{{$line_item->price}},
+                                    {{$line_item->quantity}}">
+                                        <span class="glyphicon glyphicon-trash"></span> Delete
+                                    </button>
+                                </td>
                             </tr>
                         @endforeach
                             <tr>
                                 <td><input class="form-control" type="text" name="description" placeholder="Description"></td>
                                 <td><input class="form-control" type="number" name="price" placeholder="Price"></td>
                                 <td><input class="form-control" type="number" name="quantity" placeholder="Quantity"></td>
+                                <td><input class="form-control" type="number" name="test" placeholder="test"></td>
                             </tr>
                         </tbody>
                     </table>
@@ -116,3 +130,200 @@
     </div>
 </div>
 @endsection
+
+            <div id="myModal" class="modal" role="dialog">
+                <div class="modal-dialog">
+                    <!-- Modal content-->
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                            <h4 class="modal-title"></h4>
+                        </div>
+                        <div class="modal-body">
+                            <form class="form-horizontal" role="form">
+                            <div class="form-group">
+                                    <label class="control-label col-sm-2" for="id">ID:</label>
+                                    <div class="col-sm-10">
+                                        <input type="text" class="form-control" id="id" disabled>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="control-label col-sm-2" for="description">Description:</label>
+                                    <div class="col-sm-10">
+                                        <input type="text" class="form-control" id="description">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="control-label col-sm-2" for="price">Price:</label>
+                                    <div class="col-sm-10">
+                                        <input type="number" class="form-control" id="price">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="control-label col-sm-2" for="quantity">Quantity:</label>
+                                    <div class="col-sm-10">
+                                        <input type="number" class="form-control" id="quantity">
+                                    </div>
+                                </div>
+                            </form>
+                            <div class="deleteContent" style="displaye:none;">
+                                Are you sure you want to delete <span class="dname"></span> ? <span class="hidden did"></span>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn actionBtn" data-dismiss="modal">
+                                    <span id="footer_action_button" class='glyphicon'> </span>
+                                </button>
+                                <button type="button" class="btn btn-warning" data-dismiss="modal">
+                                    <span class='glyphicon glyphicon-remove'></span> Close
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+@push('script')
+    <!--extra scripts-->
+    <script src="//code.jquery.com/jquery-1.12.3.js" ></script>
+    <!--script src="//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js" defer></script>
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.12/css/dataTables.bootstrap.min.css" defer/-->
+    <script>
+    $(document).ready(function() {
+        $('#itemsTable').DataTable();
+    } );
+    $(document).on('click', '.edit-modal', 
+        function() {
+                $('#footer_action_button').text("Update");
+                $('#footer_action_button').addClass('glyphicon-check');
+                $('#footer_action_button').removeClass('glyphicon-trash');
+                $('.actionBtn').addClass('btn-success');
+                $('.actionBtn').removeClass('btn-danger');
+                $('.actionBtn').removeClass('delete');
+                $('.actionBtn').addClass('edit');
+                $('.modal-title').text('Edit');
+                //$('.deleteContent').hide();
+                $('.form-horizontal').show();
+                var stuff = $(this).data('info').split(',');
+                fillmodalData(stuff)
+                $('#myModal').modal('show');
+        });
+
+    function fillmodalData(details){
+        var path = window.location.pathname.split('/');
+        //$('#id').val(path[2]);
+        $('#id').val(details[0]);
+        $('#description').val(details[1]);
+        $('#price').val(details[2]);
+        $('#quantity').val(details[3]);
+    }
+
+    $('.modal-footer').on('click', '.edit', function() 
+    {
+            $.ajax({
+                type: 'post',
+                url: '/api/lineitems/update',
+                data: {
+                    '_token': $('input[name=_token]').val(),
+                    'id': $("#id").val(),
+                    'description': $('#description').val(),
+                    'price': $('#price').val(),
+                    'quantity': $('#quantity').val(),
+                },
+                success: function(data) {
+                    if (data.errors){
+                        $('#myModal').modal('show');
+                        if(data.errors.description) {
+                            $('.desc_error').removeClass('hidden');
+                            $('.desc_error').text("Description can't be empty !");
+                        }
+                        if(data.errors.price) {
+                            $('.price_error').removeClass('hidden');
+                            $('.price_error').text("Price can't be empty !");
+                        }
+                        if(data.errors.quantity) {
+                            $('.quant_error').removeClass('hidden');
+                            $('.quant_error').text("Quantity can't be empty !");
+                        }
+                    }
+                    else 
+                    {
+                        $('.error').addClass('hidden');
+                        $('#item' + data.id).replaceWith("<tr id='item" + data.id + "'><td>" + data.description +
+                            "</td><td class='text-right'>" + data.price + "</td><td class='text-right'>" + data.quantity +
+                            "</td><td><button class='edit-modal btn btn-info' data-info='" + 
+                            data.id+","+data.description+","+data.price+","+
+                            data.quantity+"'><span class='glyphicon glyphicon-edit'></span> Edit</button> <button class='delete-modal btn btn-danger' data-info='"
+                             + data.id+","+data.description+","+data.price+","+data.quantity+
+                             "' ><span class='glyphicon glyphicon-trash'></span> Delete</button></td></tr>"
+                            );
+                        //$('#itemsTable').DataTable().clear();
+                        //$('#itemsTable').DataTable().ajax.url(window.location.pathname).load();
+                    }
+                }
+            });
+    });
+
+    /*$("#add").click(function() {
+        $.ajax({
+            type: 'post',
+            url: '/addItem',
+            data: {
+                '_token': $('input[name=_token]').val(),
+                'name': $('input[name=name]').val()
+            },
+            success: function(data) {
+                if ((data.errors)){
+                $('.error').removeClass('hidden');
+                    $('.error').text(data.errors.name);
+                }
+                else {
+                    $('.error').addClass('hidden');
+                    $('#itemsTable').append("<tr class='item" + line_items.id + "'><td>" + line_items.id + 
+                    "</td><td>" + line_items.desc + "</td><td>" + line_items.price + "</td><td>" + 
+                    line_items.quant + "</td><td><button class='edit-modal btn btn-info' data-id='" + 
+                    line_items.id + "' data-desc='" + line_items.desc + "' data-price='" + line_items.price 
+                    + "' data-quant='" + line_items.quant + 
+                    "'><span class='glyphicon glyphicon-edit'></span> Edit</button> <button class='delete-modal btn btn-danger' data-id='" 
+                    + line_items.id + "' data-desc='" + line_items.desc + "'' data-price='" + line_items.price 
+                    + "'' data-quant='" + line_items.quant + "'><span class='glyphicon glyphicon-trash'></span> Delete</button></td></tr>"
+                    );
+                }
+            },
+
+        });
+        $('#desc').val('');
+        $('#price').val('');
+        $('#quant').val('');
+    });*/
+    $(document).on('click', '.delete-modal', function() {
+        $('#footer_action_button').text(" Delete");
+        $('#footer_action_button').removeClass('glyphicon-check');
+        $('#footer_action_button').addClass('glyphicon-trash');
+        $('.actionBtn').removeClass('btn-success');
+        $('.actionBtn').addClass('btn-danger');
+        $('.actionBtn').removeClass('edit');
+        $('.actionBtn').addClass('delete');
+        $('.modal-title').text('Delete');
+        $('.deleteContent').show();
+        $('.form-horizontal').hide();
+        var stuff = $(this).data('info').split(',');
+        $('.did').text(stuff[0]);
+        $('.dname').html(stuff[0] +" "+stuff[1]);
+        $('#myModal').modal('show');
+    });
+
+    $('.modal-footer').on('click', '.delete', function() {
+        $.ajax({
+            type: 'post',
+            url: '/api/lineitems/destroy',
+            data: {
+                '_token': $('input[name=_token]').val(),
+                'id': $('.did').text()
+            },
+            success: function(data) {
+                $('.item' + $('.did').text()).remove();
+            }
+        });
+    });
+    </script>
+@endpush

--- a/laravel/resources/views/quotes.blade.php
+++ b/laravel/resources/views/quotes.blade.php
@@ -8,7 +8,15 @@
             <div class="card">
                 <div class="card-header text-center"><h4>{{ __('Quotes') }}</h4></div>
                 <div class="card-body">
-                    <table class="table table-striped ">
+                <div>
+                <select id="statusFilter" class = "form-control" style="width:150px;">
+                    <option value="">Any status</option>
+                    <option value="unfinalized">unfinalized</option>
+                    <option value="finalized">finalized</option>
+                    <option value="sanctioned">sanctioned</option>
+                </select>
+                </div>
+                    <table class="table table-striped " id="quotesTable">
                         <thead class="thead-dark">
                             <tr>
                                 <th scope="col">Customer</th>
@@ -43,3 +51,41 @@
 </div>
 
 @endsection
+
+@push('script')
+    <script src="//code.jquery.com/jquery-1.12.3.js" ></script>
+    <script src="//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js" defer></script>
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.12/css/dataTables.bootstrap.min.css" defer/>
+    <script>
+    $(document).ready(function() {
+        $('#quotesTable').DataTable({
+            "searching":true
+        });
+        var table = $('#quotesTable').DataTable();
+        $("#quotesTable_filter.dataTables_filter").append($("#statusFilter"));
+        var categoryIndex = 0;
+      $("#quotesTable th").each(function (i) 
+      {
+        if ($($(this)).html() == "Status") 
+        {
+          statusIndex = i; 
+          return false;
+        }
+      });
+      $.fn.dataTable.ext.search.push(
+        function (settings, data, dataIndex) {
+          var selected = $('#statusFilter').val()
+          var status = data[statusIndex];
+          if (selected === "" || status === selected) {
+            return true;
+          }
+          return false;
+        }
+      );
+      $("#statusFilter").change(function (e) {
+        table.draw();
+      });
+      table.draw();
+    });
+    </script>
+@endpush

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -22,3 +22,5 @@ Route::post ( '/lineitems/update', [App\Http\Controllers\LineItemController::cla
 
 Route::post ( '/lineitems/destroy', [App\Http\Controllers\LineItemController::class, 'destroy'])->name('api.lineitems.destroy');
 
+Route::post ( '/lineitems/create', [App\Http\Controllers\LineItemController::class, 'create'])->name('api.lineitems.create');
+

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -17,3 +17,8 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post ( '/lineitems/update', [App\Http\Controllers\LineItemController::class, 'update'])->name('api.lineitems.update');
+
+Route::post ( '/lineitems/destroy', [App\Http\Controllers\LineItemController::class, 'destroy'])->name('api.lineitems.destroy');
+


### PR DESCRIPTION
JS edit and delete buttons to line items on /quote/{id} work but looks like might be unnecessary now

Quotes table is sortable, searchable, and filterable by status. It might seem like you have to click the column headers a couple times for them to sort by that column, but that might just be due to there being a just a few records and happening to already be in that order.

Making a table sortable, paginated, and searchable is as quick and easy as adding "id = 'tableID" to the table tag and then the following at the end of the .blade.php file:
@push('script')
    <script src="//code.jquery.com/jquery-1.12.3.js" ></script>
    <script src="//cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js" defer></script>
    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.12/css/dataTables.bootstrap.min.css" defer/>
    <script>
    $(document).ready(function() {
        $('#tableID').DataTable();
     }
     </script>
@endpush

From there, you can disable certain features if you want, or enable them if they seem to be being overpowered by something else. 
ex: putting "$(document).ready(function() {
                     $('#tableID').DataTable({
                           "searching":true
                      });
                      }"
if for some reason the search bar isn't showing up.
Make sure that "@stack('script')" is in resources/views/layouts/app.blade.php though.


There's the beginning of an add function in here but it looks like it might be unnecessary.
I think that's everything.